### PR TITLE
Fixed "SecureUser" references in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ func Private(w http.ResponseWriter, r *http.Request) {
 ```
 
 If you want additional user data you must implement our custom handler, and wrap
-it with the `auth.SecureUserFunc`. This adds an additional `User` parameter to
+it with the `auth.SecureUser`. This adds an additional `User` parameter to
 your method signature that provides the full set of available user data:
 
 ```go
@@ -72,7 +72,7 @@ func Private(w http.ResponseWriter, r *http.Request, u auth.User) {
 	...
 }
 
-http.HandleFunc("/foo", auth.SecureUserFunc(Private))
+http.HandleFunc("/foo", auth.SecureUser(Private))
 ```
 
 # Configuration

--- a/auth.go
+++ b/auth.go
@@ -24,7 +24,7 @@ type AuthHandler struct {
 // New allocates and returns a new AuthHandler, using the specified
 // AuthProvider.
 func New(p AuthProvider) *AuthHandler {
-	return &AuthHandler{ provider : p }
+	return &AuthHandler{provider: p}
 }
 
 // Google allocates and returns a new AuthHandler, using the GoogleProvider.
@@ -116,27 +116,26 @@ type AuthProvider interface {
 // AuthConfig holds configuration parameters used when authenticating a user and
 // creating a secure cookie user session.
 type AuthConfig struct {
-	CookieSecret          []byte
-	CookieName            string
-	CookieExp             time.Duration
-	CookieMaxAge          int
-	CookieSecure          bool
-	CookieHttpOnly        bool
-	LoginRedirect         string
-	LoginSuccessRedirect  string
-	
+	CookieSecret         []byte
+	CookieName           string
+	CookieExp            time.Duration
+	CookieMaxAge         int
+	CookieSecure         bool
+	CookieHttpOnly       bool
+	LoginRedirect        string
+	LoginSuccessRedirect string
 }
 
 // Config is the default implementation of Config, and is used by
 // DetaultAuthCallback, Secure, and SecureFunc.
 var Config = &AuthConfig{
-	CookieName:            "_sess",
-	CookieExp:             time.Hour * 24 * 14,
-	CookieMaxAge:          0,
-	CookieSecure:          true,
-	CookieHttpOnly:        true,
-	LoginRedirect:         "/auth/login",
-	LoginSuccessRedirect:  "/",
+	CookieName:           "_sess",
+	CookieExp:            time.Hour * 24 * 14,
+	CookieMaxAge:         0,
+	CookieSecure:         true,
+	CookieHttpOnly:       true,
+	LoginRedirect:        "/auth/login",
+	LoginSuccessRedirect: "/",
 }
 
 // Passes back the OAuth Token. This will likely be the oauth2.Token or the
@@ -148,13 +147,13 @@ type Token interface {
 
 // A User is returned by the AuthProvider upon success authentication.
 type User interface {
-	Id()       string // Unique identifier of the user
+	Id() string       // Unique identifier of the user
 	Provider() string // Name of the Authentication Provider (ie google, github)
-	Name()     string // Name of the User (ie lastname, firstname)
-	Email()    string // Email Address of the User
-	Org()      string // Company or Organization the User belongs to
-	Picture()  string // URL of the User's Profile picture
-	Link()     string // URL of the User's Profile page
+	Name() string     // Name of the User (ie lastname, firstname)
+	Email() string    // Email Address of the User
+	Org() string      // Company or Organization the User belongs to
+	Picture() string  // URL of the User's Profile picture
+	Link() string     // URL of the User's Profile page
 }
 
 // An implementation of User, for internal package use only.
@@ -213,7 +212,7 @@ func SecureUser(handler SecureHandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		//else, invoke the handler and provide the suer
+		//else, invoke the handler and provide the user
 		handler(w, r, user)
 	}
 }
@@ -221,7 +220,7 @@ func SecureUser(handler SecureHandlerFunc) http.HandlerFunc {
 // SecureGuest will attempt to retireve authenticated User details from
 // the current session when invoking the auth.SecureHandlerFunc function. If no
 // User details are found the handler will allow the user to proceed as a guest,
-// which means the User details will be nil. 
+// which means the User details will be nil.
 //
 // This function is intended for pages that are Publicly visible, but display
 // additional details for authenticated users.
@@ -235,7 +234,7 @@ func SecureGuest(handler SecureHandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		//else, invoke the handler and provide the suer
+		//else, invoke the handler and provide the user
 		handler(w, r, user)
 	}
 }

--- a/examples/google/README.md
+++ b/examples/google/README.md
@@ -18,6 +18,6 @@ When you click the Register Application button you will be given the Client Id a
 ###Required Flags
 In order to start the application you will need to pass in the Client Id and Secret Key as args:
 
-    ./google -access_token a69c7cca3b3121a40934 -secret_key 1ac41f49814k9asdfs9fd798we87s8f79904abaa91ac
+    ./google -access_key a69c7cca3b3121a40934 -secret_key 1ac41f49814k9asdfs9fd798we87s8f79904abaa91ac
 
 You can then visit your application at `http://localhost:8080/`

--- a/examples/google/google_demo.go
+++ b/examples/google/google_demo.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"flag"
-    "net/http"
+	"fmt"
 	"github.com/bradrydzewski/go.auth"
+	"net/http"
 )
 
 var homepage = `
@@ -26,6 +26,21 @@ var privatepage = `
 	</head>
 	<body>
 		<div>oauth url: <a href="%s" target="_blank">%s</a></div>
+		<div><a href="/private/user">more details</a></div>
+		<div><a href="/auth/logout">Logout</a><div>
+	</body>
+</html>
+`
+
+var privateuser = `
+<html>
+	<head>
+		<title>Login</title>
+	</head>
+	<body>
+		<div>oauth url: <a href="%s" target="_blank">%s</a></div>
+		<div>name: %s</div>
+		<div>email: %s</div>
 		<div><a href="/auth/logout">Logout</a><div>
 	</body>
 </html>
@@ -35,6 +50,15 @@ var privatepage = `
 func Private(w http.ResponseWriter, r *http.Request) {
 	user := r.URL.User.Username()
 	fmt.Fprintf(w, fmt.Sprintf(privatepage, user, user))
+}
+
+// private webpage with additional user data
+func PrivateUser(w http.ResponseWriter, r *http.Request, u auth.User) {
+	user := u.Id()
+	name := u.Name()
+	email := u.Email()
+
+	fmt.Fprintf(w, fmt.Sprintf(privateuser, user, user, name, email))
 }
 
 // public webpage, no authentication required
@@ -69,7 +93,7 @@ func main() {
 	http.Handle("/auth/login", googHandler)
 
 	// logout handler
-    http.HandleFunc("/auth/logout", Logout)
+	http.HandleFunc("/auth/logout", Logout)
 
 	// public urls
 	http.HandleFunc("/", Public)
@@ -77,6 +101,8 @@ func main() {
 	// private, secured urls
 	http.HandleFunc("/private", auth.SecureFunc(Private))
 
+	// private url with additional user data
+	http.HandleFunc("/private/user", auth.SecureUser(PrivateUser))
 
 	println("google demo starting on port 8080")
 	err := http.ListenAndServe(":8080", nil)
@@ -84,18 +110,3 @@ func main() {
 		fmt.Println(err)
 	}
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
I've fixed a couple of inconsistencies between the documentation in the README and the implementation of `SecureUser`.

Previously: the docs referred to `SecureUserFunc`, which does not exist. I've changed the docs to properly use `SecureUser` in the example when passing additional user details.

I've also updated the Google example to include the additional user details as a second route under `/private/user` and corrected a discrepancy between the Google example docs and the actual flag expected in the example (now properly refers to `access_key`).

The examples run and work as expected. I've attempted to copy the existing approach/templates where possible to maintain a consistent style.
