### PR TITLE
Fix signing of requests which contain query parameters in them.

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -24,7 +24,7 @@ type AuthHandler struct {
 // New allocates and returns a new AuthHandler, using the specified
 // AuthProvider.
 func New(p AuthProvider) *AuthHandler {
-	return &AuthHandler{ provider : p }
+	return &AuthHandler{provider: p}
 }
 
 // Google allocates and returns a new AuthHandler, using the GoogleProvider.
@@ -116,27 +116,26 @@ type AuthProvider interface {
 // AuthConfig holds configuration parameters used when authenticating a user and
 // creating a secure cookie user session.
 type AuthConfig struct {
-	CookieSecret          []byte
-	CookieName            string
-	CookieExp             time.Duration
-	CookieMaxAge          int
-	CookieSecure          bool
-	CookieHttpOnly        bool
-	LoginRedirect         string
-	LoginSuccessRedirect  string
-	
+	CookieSecret         []byte
+	CookieName           string
+	CookieExp            time.Duration
+	CookieMaxAge         int
+	CookieSecure         bool
+	CookieHttpOnly       bool
+	LoginRedirect        string
+	LoginSuccessRedirect string
 }
 
 // Config is the default implementation of Config, and is used by
 // DetaultAuthCallback, Secure, and SecureFunc.
 var Config = &AuthConfig{
-	CookieName:            "_sess",
-	CookieExp:             time.Hour * 24 * 14,
-	CookieMaxAge:          0,
-	CookieSecure:          true,
-	CookieHttpOnly:        true,
-	LoginRedirect:         "/auth/login",
-	LoginSuccessRedirect:  "/",
+	CookieName:           "_sess",
+	CookieExp:            time.Hour * 24 * 14,
+	CookieMaxAge:         0,
+	CookieSecure:         true,
+	CookieHttpOnly:       true,
+	LoginRedirect:        "/auth/login",
+	LoginSuccessRedirect: "/",
 }
 
 // Passes back the OAuth Token. This will likely be the oauth2.Token or the
@@ -148,13 +147,13 @@ type Token interface {
 
 // A User is returned by the AuthProvider upon success authentication.
 type User interface {
-	Id()       string // Unique identifier of the user
+	Id() string       // Unique identifier of the user
 	Provider() string // Name of the Authentication Provider (ie google, github)
-	Name()     string // Name of the User (ie lastname, firstname)
-	Email()    string // Email Address of the User
-	Org()      string // Company or Organization the User belongs to
-	Picture()  string // URL of the User's Profile picture
-	Link()     string // URL of the User's Profile page
+	Name() string     // Name of the User (ie lastname, firstname)
+	Email() string    // Email Address of the User
+	Org() string      // Company or Organization the User belongs to
+	Picture() string  // URL of the User's Profile picture
+	Link() string     // URL of the User's Profile page
 }
 
 // An implementation of User, for internal package use only.
@@ -221,7 +220,7 @@ func SecureUser(handler SecureHandlerFunc) http.HandlerFunc {
 // SecureGuest will attempt to retireve authenticated User details from
 // the current session when invoking the auth.SecureHandlerFunc function. If no
 // User details are found the handler will allow the user to proceed as a guest,
-// which means the User details will be nil. 
+// which means the User details will be nil.
 //
 // This function is intended for pages that are Publicly visible, but display
 // additional details for authenticated users.

--- a/bitbucket.go
+++ b/bitbucket.go
@@ -11,14 +11,13 @@ type BitbucketUser struct {
 	UserFirstName string `json:"first_name"`
 }
 
-func (u *BitbucketUser) Id()       string { return u.UserId }
+func (u *BitbucketUser) Id() string       { return u.UserId }
 func (u *BitbucketUser) Provider() string { return "bitbucket.org" }
-func (u *BitbucketUser) Name()     string { return u.UserId }
-func (u *BitbucketUser) Email()    string { return "" }
-func (u *BitbucketUser) Link()     string { return "https://bitbucket.org/"+u.UserId }
-func (u *BitbucketUser) Picture()  string { return u.UserPicture }
-func (u *BitbucketUser) Org()      string { return "" }
-
+func (u *BitbucketUser) Name() string     { return u.UserId }
+func (u *BitbucketUser) Email() string    { return "" }
+func (u *BitbucketUser) Link() string     { return "https://bitbucket.org/" + u.UserId }
+func (u *BitbucketUser) Picture() string  { return u.UserPicture }
+func (u *BitbucketUser) Org() string      { return "" }
 
 // BitbucketProvider is an implementation of Bitbucket's Oauth1.0a protocol.
 // See https://confluence.atlassian.com/display/BITBUCKET/OAuth+on+Bitbucket
@@ -67,5 +66,5 @@ func (self *BitbucketProvider) GetAuthenticatedUser(w http.ResponseWriter, r *ht
 	}
 
 	return wrapper.User, token, nil
-	
+
 }

--- a/cookie.go
+++ b/cookie.go
@@ -11,8 +11,8 @@ import (
 
 // Error messages related to the Secure Cookie parsing and verification
 var (
-	ErrSessionExpired = errors.New("User session Expired")
-	ErrInvalidCookieFormat= errors.New("Invalid Cookie Format")
+	ErrSessionExpired      = errors.New("User session Expired")
+	ErrInvalidCookieFormat = errors.New("Invalid Cookie Format")
 )
 
 // SetUserCookie creates a secure cookie for the given username, indicating the
@@ -46,9 +46,9 @@ func SetUserCookieOpts(w http.ResponseWriter, cookie *http.Cookie, user User) {
 	// the strings are quoted to ensure they aren't tampered with
 	// TODO explore storing string as a URL Parameter String
 	userStr := fmt.Sprintf("%q|%q|%q|%q|%q|%q|%q",
-							user.Id(), user.Provider(), user.Name(),
-							user.Email(), user.Link(), user.Picture(),
-							user.Org())
+		user.Id(), user.Provider(), user.Name(),
+		user.Email(), user.Link(), user.Picture(),
+		user.Org())
 
 	// set the cookie's value
 	cookie.Value = authcookie.New(userStr, exp, Config.CookieSecret)
@@ -82,7 +82,7 @@ func GetUserCookie(r *http.Request) (User, error) {
 	return GetUserCookieName(r, Config.CookieName)
 }
 
-// GetUserCookieName will get the User data from the http session for the 
+// GetUserCookieName will get the User data from the http session for the
 // specified secure cookie. If the session is inactive, or if the session has
 // expired, then an error will be returned.
 func GetUserCookieName(r *http.Request, name string) (User, error) {
@@ -111,15 +111,15 @@ func GetUserCookieName(r *http.Request, name string) (User, error) {
 	}
 
 	// parse the user data from the cookie string
-	u := user { }
+	u := user{}
 	_, err = fmt.Fscanf(strings.NewReader(login), "%q|%q|%q|%q|%q|%q|%q",
-								&u.id, &u.provider, &u.name, &u.email,
-								&u.link, &u.picture, &u.org)
+		&u.id, &u.provider, &u.name, &u.email,
+		&u.link, &u.picture, &u.org)
 
 	// if we were unable to parse the cookie return an exception
 	if err != nil {
 		return nil, ErrInvalidCookieFormat
-	}	
+	}
 
 	return &u, err
 }

--- a/examples/bitbucket/bitbucket_demo.go
+++ b/examples/bitbucket/bitbucket_demo.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"flag"
-    "net/http"
+	"fmt"
 	"github.com/bradrydzewski/go.auth"
+	"net/http"
 )
 
 var homepage = `
@@ -69,7 +69,7 @@ func main() {
 	http.Handle("/auth/bitbucket", bitbucketHandler)
 
 	// logout handler
-    http.HandleFunc("/auth/logout", Logout)
+	http.HandleFunc("/auth/logout", Logout)
 
 	// public urls
 	http.HandleFunc("/", Public)
@@ -77,25 +77,9 @@ func main() {
 	// private, secured urls
 	http.HandleFunc("/private", auth.SecureFunc(Private))
 
-
 	println("bitbucket demo starting on port 8080")
 	err := http.ListenAndServe(":8080", nil)
 	if err != nil {
 		fmt.Println(err)
 	}
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/examples/github/github_demo.go
+++ b/examples/github/github_demo.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"flag"
-    "net/http"
+	"fmt"
 	"github.com/bradrydzewski/go.auth"
+	"net/http"
 )
 
 var homepage = `
@@ -87,7 +87,7 @@ func main() {
 	http.Handle("/auth/login", githubHandler)
 
 	// logout handler
-    http.HandleFunc("/auth/logout", Logout)
+	http.HandleFunc("/auth/logout", Logout)
 
 	// public urls
 	http.HandleFunc("/", Public)
@@ -102,18 +102,3 @@ func main() {
 		fmt.Println(err)
 	}
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/examples/google/google_demo.go
+++ b/examples/google/google_demo.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"flag"
-    "net/http"
+	"fmt"
 	"github.com/bradrydzewski/go.auth"
+	"net/http"
 )
 
 var homepage = `
@@ -69,7 +69,7 @@ func main() {
 	http.Handle("/auth/login", googHandler)
 
 	// logout handler
-    http.HandleFunc("/auth/logout", Logout)
+	http.HandleFunc("/auth/logout", Logout)
 
 	// public urls
 	http.HandleFunc("/", Public)
@@ -77,25 +77,9 @@ func main() {
 	// private, secured urls
 	http.HandleFunc("/private", auth.SecureFunc(Private))
 
-
 	println("google demo starting on port 8080")
 	err := http.ListenAndServe(":8080", nil)
 	if err != nil {
 		fmt.Println(err)
 	}
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/examples/multiple/multiple_demo.go
+++ b/examples/multiple/multiple_demo.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"flag"
-    "net/http"
+	"fmt"
 	"github.com/bradrydzewski/go.auth"
+	"net/http"
 )
 
 var homepage = `
@@ -93,7 +93,7 @@ func main() {
 	http.HandleFunc("/private", auth.SecureFunc(Private))
 
 	// logout handler
-    http.HandleFunc("/auth/logout", func (w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/auth/logout", func(w http.ResponseWriter, r *http.Request) {
 		auth.DeleteUserCookie(w, r)
 		http.Redirect(w, r, "/", http.StatusSeeOther)
 	})

--- a/examples/twitter/twitter_demo.go
+++ b/examples/twitter/twitter_demo.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"flag"
-    "net/http"
+	"fmt"
 	"github.com/bradrydzewski/go.auth"
+	"net/http"
 )
 
 var homepage = `
@@ -67,7 +67,7 @@ func main() {
 	http.Handle("/auth/login", twitterHandler)
 
 	// logout handler
-    http.HandleFunc("/auth/logout", Logout)
+	http.HandleFunc("/auth/logout", Logout)
 
 	// public urls
 	http.HandleFunc("/", Public)

--- a/oauth1.go
+++ b/oauth1.go
@@ -82,7 +82,7 @@ func (self *OAuth1Mixin) AuthorizeToken(w http.ResponseWriter, r *http.Request) 
 	}
 
 	//Delete the request Token ...don't need it anymore
-	DeleteUserCookieName(w,r,"_token")
+	DeleteUserCookieName(w, r, "_token")
 
 	//Parse the verification code from the Redirect URL
 	verifier := r.URL.Query().Get("oauth_verifier")
@@ -129,4 +129,3 @@ func (self *OAuth1Mixin) GetAuthenticatedUser(endpoint string, token *oauth1.Acc
 	//unmarshal user json
 	return json.Unmarshal(userData, &resp)
 }
-

--- a/oauth1/consumer.go
+++ b/oauth1/consumer.go
@@ -67,7 +67,7 @@ func (c *Consumer) RequestToken() (*RequestToken, error) {
 	}
 
 	// sign the request
-	err := c.SignParams(&req, nil, map[string]string{ "oauth_callback":c.CallbackURL })
+	err := c.SignParams(&req, nil, map[string]string{"oauth_callback": c.CallbackURL})
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (c *Consumer) AuthorizeToken(t *RequestToken, verifier string) (*AccessToke
 	}
 
 	// sign the request
-	err := c.SignParams(&req, t, map[string]string{ "oauth_verifier":verifier })
+	err := c.SignParams(&req, t, map[string]string{"oauth_verifier": verifier})
 	if err != nil {
 		return nil, err
 	}
@@ -156,11 +156,11 @@ func (c *Consumer) SignParams(req *http.Request, token Token, params map[string]
 
 	// ensure default parameters are set
 	//params["oauth_token"]            = token.Token()
-	params["oauth_consumer_key"]     = c.ConsumerKey
-	params["oauth_nonce"]            = nonce()
+	params["oauth_consumer_key"] = c.ConsumerKey
+	params["oauth_nonce"] = nonce()
 	params["oauth_signature_method"] = "HMAC-SHA1"
-	params["oauth_timestamp"]        = timestamp()
-	params["oauth_version"]          = "1.0"
+	params["oauth_timestamp"] = timestamp()
+	params["oauth_version"] = "1.0"
 
 	// we'll need to sign any form values?
 	if req.Form != nil {
@@ -169,7 +169,7 @@ func (c *Consumer) SignParams(req *http.Request, token Token, params map[string]
 		}
 	}
 
-	// we'll also need to sign any URL parameter 
+	// we'll also need to sign any URL parameter
 	queryParams := req.URL.Query()
 	for k, _ := range queryParams {
 		params[k] = queryParams.Get(k)
@@ -187,7 +187,7 @@ func (c *Consumer) SignParams(req *http.Request, token Token, params map[string]
 	params["oauth_signature"] = sign(base, key)
 
 	//HACK: we were previously including params in the Authorization
-	//      header that shouldn't be. so for now, we'll filter 
+	//      header that shouldn't be. so for now, we'll filter
 	//authStringParams := map[string]string{}
 	//for k,v := range params {
 	//	if strings.HasPrefix(k, "oauth_") {
@@ -199,14 +199,14 @@ func (c *Consumer) SignParams(req *http.Request, token Token, params map[string]
 	if req.Header == nil {
 		req.Header = http.Header{}
 	}
-	
+
 	// add the authorization header string
-	req.Header.Add("Authorization", authorizationString(params))//params))
+	req.Header.Add("Authorization", authorizationString(params)) //params))
 
 	// ensure the appropriate content-type is set for POST,
 	// assuming the field is not populated
 	if (req.Method == "POST" || req.Method == "PUT") && len(req.Header.Get("Content-Type")) == 0 {
-		req.Header.Set("Content-Type","application/x-www-form-urlencoded")
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	}
 
 	return nil
@@ -244,16 +244,16 @@ func sign(message, key string) string {
 // Gets the default set of OAuth1.0a headers.
 func headers(consumerKey string) map[string]string {
 	return map[string]string{
-		"oauth_consumer_key"     : consumerKey,
-		"oauth_nonce"            : nonce(),
-		"oauth_signature_method" : "HMAC-SHA1",
-		"oauth_timestamp"        : timestamp(),
-		"oauth_version"          : "1.0",
+		"oauth_consumer_key":     consumerKey,
+		"oauth_nonce":            nonce(),
+		"oauth_signature_method": "HMAC-SHA1",
+		"oauth_timestamp":        timestamp(),
+		"oauth_version":          "1.0",
 	}
 }
 
 func requestString(method string, uri string, params map[string]string) string {
-	
+
 	// loop through params, add keys to map
 	var keys []string
 	for key, _ := range params {
@@ -281,7 +281,7 @@ func requestString(method string, uri string, params map[string]string) string {
 }
 
 func authorizationString(params map[string]string) string {
-	
+
 	// loop through params, add keys to map
 	var keys []string
 	for key, _ := range params {
@@ -315,7 +315,6 @@ func authorizationString(params map[string]string) string {
 	return fmt.Sprintf("OAuth %s", str)
 }
 
-
 func escape(s string) string {
 	t := make([]byte, 0, 3*len(s))
 	for i := 0; i < len(s); i++ {
@@ -335,4 +334,3 @@ func isEscapable(b byte) bool {
 	return !('A' <= b && b <= 'Z' || 'a' <= b && b <= 'z' || '0' <= b && b <= '9' || b == '-' || b == '.' || b == '_' || b == '~')
 
 }
-

--- a/oauth1/consumer.go
+++ b/oauth1/consumer.go
@@ -182,8 +182,10 @@ func (c *Consumer) SignParams(req *http.Request, token Token, params map[string]
 	}
 
 	// create the oauth signature
+	uri := strings.Split(req.URL.String(), "?")[0] //According to OAuth 1.0a we should include the absolute url (ref 9.1.2).
+	base := requestString(req.Method, uri, params)
+
 	key := escape(c.ConsumerSecret) + "&" + escape(tokenSecret)
-	base := requestString(req.Method, req.URL.String(), params)
 	params["oauth_signature"] = sign(base, key)
 
 	//HACK: we were previously including params in the Authorization

--- a/oauth1/token.go
+++ b/oauth1/token.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Token interface {
-	Token()  string // Gets the oauth_token value.
+	Token() string  // Gets the oauth_token value.
 	Secret() string // Gets the oauth_token_secret.
 	Encode() string // Encode encodes the token into “URL encoded” form.
 }
@@ -26,10 +26,10 @@ type AccessToken struct {
 // NewAccessToken returns a new instance of AccessToken with the specified
 // token, secret and additional parameters.
 func NewAccessToken(token, secret string, params map[string]string) *AccessToken {
-	return &AccessToken {
-		token  : token,
-		secret : secret,
-		params : params,
+	return &AccessToken{
+		token:  token,
+		secret: secret,
+		params: params,
 	}
 }
 
@@ -60,16 +60,21 @@ func ParseAccessTokenStr(str string) (*AccessToken, error) {
 	//loop through parts to create Token
 	for key, val := range parts {
 		switch key {
-		case "oauth_token"        : token.token = val[0]
-		case "oauth_token_secret" : token.secret = val[0]
-		default                   : token.params[key] = val[0]
+		case "oauth_token":
+			token.token = val[0]
+		case "oauth_token_secret":
+			token.secret = val[0]
+		default:
+			token.params[key] = val[0]
 		}
 	}
 
 	//some error checking ...
 	switch {
-	case len(token.token) == 0  : return nil, errors.New(str)
-	case len(token.secret) == 0 : return nil, errors.New(str)
+	case len(token.token) == 0:
+		return nil, errors.New(str)
+	case len(token.secret) == 0:
+		return nil, errors.New(str)
 	}
 
 	return &token, nil
@@ -90,7 +95,7 @@ func (a *AccessToken) Encode() string {
 }
 
 // Gets the oauth_token value
-func (a *AccessToken) Token()  string { return a.token }
+func (a *AccessToken) Token() string { return a.token }
 
 // Gets the oauth_token_secret value
 func (a *AccessToken) Secret() string { return a.secret }
@@ -98,12 +103,11 @@ func (a *AccessToken) Secret() string { return a.secret }
 // Gets any additional parameters, as defined by the Service Provider.
 func (a *AccessToken) Params() map[string]string { return a.params }
 
-
 // RequestToken represents a value used by the Consumer to obtain
 // authorization from the User, and exchanged for an Access Token.
 type RequestToken struct {
-	token  string // the oauth_token value
-	secret string // the oauth_token_secret value
+	token             string // the oauth_token value
+	secret            string // the oauth_token_secret value
 	callbackConfirmed bool
 }
 
@@ -129,14 +133,16 @@ func ParseRequestTokenStr(str string) (*RequestToken, error) {
 	}
 
 	token := RequestToken{}
-	token.token  = parts.Get("oauth_token")
+	token.token = parts.Get("oauth_token")
 	token.secret = parts.Get("oauth_token_secret")
 	token.callbackConfirmed = parts.Get("oauth_callback_confirmed") == "true"
 
 	//some error checking ...
 	switch {
-	case len(token.token) == 0  : return nil, errors.New(str)
-	case len(token.secret) == 0 : return nil, errors.New(str)
+	case len(token.token) == 0:
+		return nil, errors.New(str)
+	case len(token.secret) == 0:
+		return nil, errors.New(str)
 	}
 
 	return &token, nil
@@ -153,7 +159,7 @@ func (r *RequestToken) Encode() string {
 }
 
 // Gets the oauth_token value
-func (r *RequestToken) Token()  string { return r.token }
+func (r *RequestToken) Token() string { return r.token }
 
 // Gets the oauth_token_secret value
 func (r *RequestToken) Secret() string { return r.secret }

--- a/oauth1/token_test.go
+++ b/oauth1/token_test.go
@@ -8,9 +8,9 @@ import (
 
 // Test the ability to parse a URL query string and unmarshal to a RequestToken.
 func TestParseRequestTokenStr(t *testing.T) {
-	oauth_token:="c0cf8793d39d46ab"
-	oauth_token_secret:="FMMj3w7plPEyhK8ZZ9lBsp"
-	oauth_callback_confirmed:=true
+	oauth_token := "c0cf8793d39d46ab"
+	oauth_token_secret := "FMMj3w7plPEyhK8ZZ9lBsp"
+	oauth_callback_confirmed := true
 
 	values := url.Values{}
 	values.Set("oauth_token", oauth_token)
@@ -31,10 +31,10 @@ func TestParseRequestTokenStr(t *testing.T) {
 
 // Test the ability to Encode a RequestToken to a URL query string.
 func TestEncodeRequestToken(t *testing.T) {
-	token := RequestToken {
-		token             : "c0cf8793d39d46ab",
-		secret            : "FMMj3w7plPEyhK8ZZ9lBsp",
-		callbackConfirmed : true,
+	token := RequestToken{
+		token:             "c0cf8793d39d46ab",
+		secret:            "FMMj3w7plPEyhK8ZZ9lBsp",
+		callbackConfirmed: true,
 	}
 
 	tokenStr := token.Encode()
@@ -46,9 +46,9 @@ func TestEncodeRequestToken(t *testing.T) {
 
 // Test the ability to parse a URL query string and unmarshal to an AccessToken.
 func TestEncodeAccessTokenStr(t *testing.T) {
-	oauth_token:="c0cf8793d39d46ab"
-	oauth_token_secret:="FMMj3w7plPEyhK8ZZ9lBsp"
-	oauth_callback_confirmed:=true
+	oauth_token := "c0cf8793d39d46ab"
+	oauth_token_secret := "FMMj3w7plPEyhK8ZZ9lBsp"
+	oauth_callback_confirmed := true
 
 	values := url.Values{}
 	values.Set("oauth_token", oauth_token)
@@ -69,10 +69,10 @@ func TestEncodeAccessTokenStr(t *testing.T) {
 
 // Test the ability to Encode an AccessToken to a URL query string.
 func TestEncodeAccessToken(t *testing.T) {
-	token := AccessToken {
-		token  : "c0cf8793d39d46ab",
-		secret : "FMMj3w7plPEyhK8ZZ9lBsp",
-		params : map[string]string{ "user" : "dr_van_nostrand" },
+	token := AccessToken{
+		token:  "c0cf8793d39d46ab",
+		secret: "FMMj3w7plPEyhK8ZZ9lBsp",
+		params: map[string]string{"user": "dr_van_nostrand"},
 	}
 
 	tokenStr := token.Encode()

--- a/oauth2.go
+++ b/oauth2.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"net/url"
-	"math/rand"
-	"time"
 	"strconv"
+	"time"
 
 	"github.com/bradrydzewski/go.auth/oauth2"
 )
@@ -56,7 +56,7 @@ func (self *OAuth2Mixin) GetAuthenticatedUser(endpoint string, accessToken strin
 
 	//create the user url
 	endpointUrl, _ := url.Parse(endpoint)
-	endpointUrl.RawQuery = "access_token="+accessToken
+	endpointUrl.RawQuery = "access_token=" + accessToken
 
 	//create the http request for the user Url
 	req := http.Request{

--- a/oauth2/const.go
+++ b/oauth2/const.go
@@ -16,7 +16,7 @@ const (
 	GrantTypeAuthorizationCode = "authorization_code"
 
 	// grant_type for requesting access to resources owned by the
-	// registered application (client). 
+	// registered application (client).
 	GrantTypeClientCredentials = "client_credentials"
 
 	// grant_type for exchanging a username and password for

--- a/oauth2_github.go
+++ b/oauth2_github.go
@@ -21,32 +21,41 @@ func (u *GitHubUser) Provider() string { return "github.com" }
 // with an explicit null value.
 
 func (u *GitHubUser) Name() string {
-	if u.UserName == nil { return "" }; 
+	if u.UserName == nil {
+		return ""
+	}
 	return u.UserName.(string)
 }
 
 func (u *GitHubUser) Email() string {
-	if u.UserEmail == nil { return "" }
+	if u.UserEmail == nil {
+		return ""
+	}
 	return u.UserEmail.(string)
 }
 
 func (u *GitHubUser) Link() string {
-	if u.UserLink == nil { return "" }
+	if u.UserLink == nil {
+		return ""
+	}
 	return u.UserLink.(string)
 }
 
 func (u *GitHubUser) Picture() string {
-	if u.UserGravatar == nil { return "" }
+	if u.UserGravatar == nil {
+		return ""
+	}
 	// use the Gravatar Id instead of the Avatar URL, which has a bunch
 	// of un-necessary data (as far as I can tell) appended to the end.
 	return "https://secure.gravatar.com/avatar/" + u.UserGravatar.(string)
 }
 
 func (u *GitHubUser) Org() string {
-	if u.UserCompany == nil { return "" }
+	if u.UserCompany == nil {
+		return ""
+	}
 	return u.UserCompany.(string)
 }
-
 
 // GithubProvider is an implementation of Github's Oauth2 protocol.
 // See http://developer.github.com/v3/oauth/
@@ -59,10 +68,10 @@ type GithubProvider struct {
 func NewGithubProvider(clientId, clientSecret, scope string) *GithubProvider {
 	github := GithubProvider{}
 	github.AuthorizationURL = "https://github.com/login/oauth/authorize"
-	github.AccessTokenURL   = "https://github.com/login/oauth/access_token"
-	github.ClientId         = clientId
-	github.ClientSecret     = clientSecret
-	github.Scope            = scope
+	github.AccessTokenURL = "https://github.com/login/oauth/access_token"
+	github.ClientId = clientId
+	github.ClientSecret = clientSecret
+	github.Scope = scope
 
 	// default the Scope if not provided
 	if len(github.Scope) == 0 {

--- a/oauth2_google.go
+++ b/oauth2_google.go
@@ -21,7 +21,7 @@ func (u *GoogleUser) Picture() string  { return u.UserPicture }
 func (u *GoogleUser) Link() string     { return u.UserLink }
 func (u *GoogleUser) Org() string      { return "" }
 
-// GoogleProvider is an implementation of Google's Oauth2 
+// GoogleProvider is an implementation of Google's Oauth2
 // for web application flow.
 // See https://developers.google.com/accounts/docs/OAuth2WebServer
 type GoogleProvider struct {
@@ -32,10 +32,10 @@ type GoogleProvider struct {
 func NewGoogleProvider(client, secret, redirect string) *GoogleProvider {
 	goog := GoogleProvider{}
 	goog.AuthorizationURL = "https://accounts.google.com/o/oauth2/auth"
-	goog.AccessTokenURL   = "https://accounts.google.com/o/oauth2/token"
-	goog.RedirectURL      = redirect
-	goog.ClientId         = client
-	goog.ClientSecret     = secret
+	goog.AccessTokenURL = "https://accounts.google.com/o/oauth2/token"
+	goog.RedirectURL = redirect
+	goog.ClientId = client
+	goog.ClientSecret = secret
 	return &goog
 }
 

--- a/openid.go
+++ b/openid.go
@@ -38,7 +38,7 @@ type OpenIdProvider struct {
 
 // NewOpenIdProvider allocates and returns a new OpenIdProvider.
 func NewOpenIdProvider(endpoint string) *OpenIdProvider {
-	return &OpenIdProvider{ endpoint }
+	return &OpenIdProvider{endpoint}
 }
 
 func (self *OpenIdProvider) RedirectRequired(r *http.Request) bool {
@@ -91,6 +91,6 @@ func (self *OpenIdProvider) GetAuthenticatedUser(w http.ResponseWriter, r *http.
 
 	// Return the User data
 	// TODO for now we are re-using the Google User
-	user := user{id: email, email: email, name: fullName, provider: self.endpoint }
+	user := user{id: email, email: email, name: fullName, provider: self.endpoint}
 	return &user, nil, nil
 }

--- a/twitter.go
+++ b/twitter.go
@@ -8,14 +8,13 @@ type TwitterUser struct {
 	UserId string `json:"screen_name"`
 }
 
-func (u *TwitterUser) Id()       string { return u.UserId }
+func (u *TwitterUser) Id() string       { return u.UserId }
 func (u *TwitterUser) Provider() string { return "twitter.com" }
-func (u *TwitterUser) Name()     string { return u.UserId }
-func (u *TwitterUser) Email()    string { return "" }
-func (u *TwitterUser) Link()     string { return "https://www.twitter.com/" + u.UserId }
-func (u *TwitterUser) Picture()  string { return "" }
-func (u *TwitterUser) Org()      string { return "" }
-
+func (u *TwitterUser) Name() string     { return u.UserId }
+func (u *TwitterUser) Email() string    { return "" }
+func (u *TwitterUser) Link() string     { return "https://www.twitter.com/" + u.UserId }
+func (u *TwitterUser) Picture() string  { return "" }
+func (u *TwitterUser) Org() string      { return "" }
 
 // TwitterProvider is an implementation of Twitters's Oauth1.0a protocol.
 // See https://dev.twitter.com/docs/auth/implementing-sign-twitter
@@ -28,7 +27,7 @@ func NewTwitterProvider(key, secret, callback string) *TwitterProvider {
 	twitter := TwitterProvider{}
 	twitter.AuthorizationURL = "https://api.twitter.com/oauth/authorize"
 	twitter.RequestTokenURL = "https://api.twitter.com/oauth/request_token"
-	twitter.AccessTokenURL =  "https://api.twitter.com/oauth/access_token"
+	twitter.AccessTokenURL = "https://api.twitter.com/oauth/access_token"
 
 	twitter.CallbackURL = callback
 	twitter.ConsumerKey = key


### PR DESCRIPTION
According to the documentation for  Signature Base String [OAuth 1.0a section 9.1.2](http://oauth.net/core/1.0a/#anchor13)
we should use the absolute url when signing the request.

This patch is based on the fmt branch, which go fmt'd the code to make it easier to contribute.

This patch has been tested with OAuth 1.0a requests which has query params.
